### PR TITLE
Param Reference

### DIFF
--- a/include/KNeighborsClassifier.h
+++ b/include/KNeighborsClassifier.h
@@ -22,6 +22,9 @@ class KNeighborsClassifier: public ClassifierMixin{
 
         void fit(const ArrayXXd& X, const ArrayXd& y);
         ArrayXd predict(const ArrayXXd& X);
+        virtual KNeighborsClassifier* clone() const{
+            return new KNeighborsClassifier(*this);
+        }
 };
 
 #endif

--- a/include/KNeighborsClassifier.h
+++ b/include/KNeighborsClassifier.h
@@ -9,8 +9,10 @@ using namespace Eigen;
 
 class KNeighborsClassifier: public ClassifierMixin{
     public:
-        int n_neighbors;
-        string weights;
+        map<string, prm> test;
+
+        int& n_neighbors;
+        string& weights;
         ArrayXXd X_;
         ArrayXd y_;
     

--- a/include/KNeighborsClassifier.h
+++ b/include/KNeighborsClassifier.h
@@ -9,10 +9,9 @@ using namespace Eigen;
 
 class KNeighborsClassifier: public ClassifierMixin{
     public:
-        map<string, prm> test;
-
         int& n_neighbors;
         string& weights;
+
         ArrayXXd X_;
         ArrayXd y_;
     

--- a/include/MinMaxScaler.h
+++ b/include/MinMaxScaler.h
@@ -22,6 +22,9 @@ class MinMaxScaler: public TransformerMixin{
         void fit(ArrayXXd X);
         void transform_inplace(ArrayXXd& X);
         void inverse_transform_inplace(ArrayXXd& X);
+        virtual MinMaxScaler* clone() const{
+            return new MinMaxScaler(*this);
+        }
 };
 
 #endif

--- a/include/MinMaxScaler.h
+++ b/include/MinMaxScaler.h
@@ -8,8 +8,9 @@ using namespace Eigen;
 
 class MinMaxScaler: public TransformerMixin{
     public:
-        float feature_min;
-        float feature_max;
+        float& feature_min;
+        float& feature_max;
+        
         ArrayXd scale_;
         ArrayXd min_;
         ArrayXd data_min_;

--- a/include/PCA.h
+++ b/include/PCA.h
@@ -8,8 +8,8 @@ using namespace Eigen;
 
 class PCA: public TransformerMixin{
     public:
-        int n_components;
-        bool center;
+        int& n_components;
+        bool& center;
 
         ArrayXXd V_;
         ArrayXd explained_variance_;

--- a/include/PCA.h
+++ b/include/PCA.h
@@ -22,6 +22,9 @@ class PCA: public TransformerMixin{
         void fit(ArrayXXd X);
         void transform_inplace(ArrayXXd& X);
         void inverse_transform_inplace(ArrayXXd& X);
+        virtual PCA* clone() const{
+            return new PCA(*this);
+        }
 };
 
 #endif

--- a/include/Pipeline.h
+++ b/include/Pipeline.h
@@ -5,13 +5,14 @@
 #include <vector>
 #include "base.h"
 
+using namespace std;
 using namespace Eigen;
 
 class Pipeline: public EstimatorMixin, public TransformerMixin{
     public:
-        vector<pair<string, BaseEstimator*>> estimators;
+        vector<pair<string, BaseEstimator*>> steps;
 
-        Pipeline(vector<pair<string, BaseEstimator*>> estimators);
+        Pipeline(vector<pair<string, BaseEstimator*>> steps);
         ~Pipeline();
 
         // Methods if we end with an Estimator
@@ -26,6 +27,12 @@ class Pipeline: public EstimatorMixin, public TransformerMixin{
 
         // For indexing
         BaseEstimator& operator[](string goal_name);
+        BaseEstimator& operator[](int idx);
+        Pipeline operator()(int start, int stop);
+
+        // Override set_params
+        void set_params(map<string,prm> new_params);
+
 };
 
 #endif

--- a/include/Pipeline.h
+++ b/include/Pipeline.h
@@ -14,6 +14,9 @@ class Pipeline: public EstimatorMixin, public TransformerMixin{
 
         Pipeline(vector<pair<string, BaseEstimator*>> steps);
         ~Pipeline();
+        // copy and assignment operators
+        Pipeline(const Pipeline& other);
+        Pipeline& operator=(const Pipeline& rhs);
 
         // Methods if we end with an Estimator
         void fit(const ArrayXXd& X, const ArrayXd& y);
@@ -26,13 +29,13 @@ class Pipeline: public EstimatorMixin, public TransformerMixin{
         void inverse_transform_inplace(ArrayXXd& X);
 
         // For indexing
-        BaseEstimator& operator[](string goal_name);
-        BaseEstimator& operator[](int idx);
+        BaseEstimator* operator[](string goal_name);
+        BaseEstimator* operator[](int idx);
         Pipeline operator()(int start, int stop);
 
-        // Override set_params
+        // Override set_params and get_params
         void set_params(map<string,prm> new_params);
-
+        map<string, prm> get_params();
 };
 
 #endif

--- a/include/Pipeline.h
+++ b/include/Pipeline.h
@@ -36,6 +36,10 @@ class Pipeline: public EstimatorMixin, public TransformerMixin{
         // Override set_params and get_params
         void set_params(map<string,prm> new_params);
         map<string, prm> get_params();
+
+        virtual Pipeline* clone() const{
+            return new Pipeline(*this);
+        }
 };
 
 #endif

--- a/include/RadiusNeighborsClassifier.h
+++ b/include/RadiusNeighborsClassifier.h
@@ -20,6 +20,9 @@ class RadiusNeighborsClassifier: public ClassifierMixin{
 
         void fit(const ArrayXXd& X, const ArrayXd& y);
         ArrayXd predict(const ArrayXXd& X);
+        virtual RadiusNeighborsClassifier* clone() const{
+            return new RadiusNeighborsClassifier(*this);
+        }
 };
 
 #endif

--- a/include/RadiusNeighborsClassifier.h
+++ b/include/RadiusNeighborsClassifier.h
@@ -9,8 +9,9 @@ using namespace Eigen;
 
 class RadiusNeighborsClassifier: public ClassifierMixin{
     public:
-        float radius;
-        string weights;
+        float& radius;
+        string& weights;
+        
         ArrayXXd X_;
         ArrayXd y_;
     

--- a/include/StandardScaler.h
+++ b/include/StandardScaler.h
@@ -8,8 +8,8 @@ using namespace Eigen;
 
 class StandardScaler: public TransformerMixin{
     public:
-        bool with_mean;
-        bool with_std;
+        bool& with_mean;
+        bool& with_std;
 
         ArrayXd mean_;
         ArrayXd var_;

--- a/include/StandardScaler.h
+++ b/include/StandardScaler.h
@@ -21,6 +21,9 @@ class StandardScaler: public TransformerMixin{
         void fit(ArrayXXd X);
         void transform_inplace(ArrayXXd& X);
         void inverse_transform_inplace(ArrayXXd& X);
+        virtual StandardScaler* clone() const{
+            return new StandardScaler(*this);
+        }
 };
 
 #endif

--- a/include/base.h
+++ b/include/base.h
@@ -2,15 +2,20 @@
 #define BASE_INTERFACES
 
 #include <Eigen/Dense>
+#include <map>
+#include <variant>
 
 using namespace Eigen;
 using namespace std;
+
+typedef variant<bool, int, float, string> prm;
 
 class BaseEstimator{
     private: 
         bool fitted_ = false;
         int n_features_;
     protected:
+        map<string, prm> params;
         // For supervised methods 
         void check_X_y(const ArrayXXd& X, const ArrayXd& y){
             if(X.rows() != y.rows())
@@ -32,10 +37,22 @@ class BaseEstimator{
                 throw std::invalid_argument( "Estimator hasn't been fitted yet" );
         }
     public:
+        // Return params 
+        map<string, prm> get_params(){ return params; }
+        // Set params using a map
+        void set_params(map<string,prm> new_params){
+            for( auto [name, new_param] : new_params){
+                if(params.count(name) == 1)
+                    params[name] = new_param;
+                else
+                    throw runtime_error("Error: Invalid Parameter to set");
+            } 
+        }
         bool is_fitted(){ return fitted_; }
         int  n_features(){ return n_features_; }
         
         BaseEstimator(void) {}
+        BaseEstimator(map<string,prm> params) : params(params) {}
         virtual ~BaseEstimator(void){}
 };
 

--- a/include/base.h
+++ b/include/base.h
@@ -40,12 +40,12 @@ class BaseEstimator{
         // Return params 
         map<string, prm> get_params(){ return params; }
         // Set params using a map
-        void set_params(map<string,prm> new_params){
+        virtual void set_params(map<string,prm> new_params){
             for( auto [name, new_param] : new_params){
                 if(params.count(name) == 1)
                     params[name] = new_param;
                 else
-                    throw runtime_error("Error: Invalid Parameter to set");
+                    throw invalid_argument("Invalid Parameter name");
             } 
         }
         bool is_fitted(){ return fitted_; }

--- a/include/base.h
+++ b/include/base.h
@@ -58,9 +58,9 @@ class BaseEstimator{
 
 class EstimatorMixin : public virtual BaseEstimator{
     public:
-        virtual void fit(const ArrayXXd& X, const ArrayXd& y) = 0;
-        virtual ArrayXd predict(const ArrayXXd& X) = 0;
-        virtual float score(const ArrayXXd& X, const ArrayXd& y) = 0;
+        virtual void fit(const ArrayXXd& X, const ArrayXd& y){}
+        virtual ArrayXd predict(const ArrayXXd& X){}
+        virtual float score(const ArrayXXd& X, const ArrayXd& y){}
 };
 
 class RegressorMixin : public EstimatorMixin{
@@ -87,9 +87,9 @@ class ClassifierMixin : public EstimatorMixin{
 
 class TransformerMixin : public virtual BaseEstimator{
     public:
-        virtual void fit(ArrayXXd X) = 0;
-        virtual void transform_inplace(ArrayXXd& X) = 0;
-        virtual void inverse_transform_inplace(ArrayXXd& X) = 0;
+        virtual void fit(ArrayXXd X){}
+        virtual void transform_inplace(ArrayXXd& X){}
+        virtual void inverse_transform_inplace(ArrayXXd& X){}
 
         // This will return a copy from the transform_inplace function
         ArrayXXd transform(ArrayXXd X){

--- a/include/base.h
+++ b/include/base.h
@@ -54,13 +54,15 @@ class BaseEstimator{
         BaseEstimator(void) {}
         BaseEstimator(map<string,prm> params) : params(params) {}
         virtual ~BaseEstimator(void){}
+        // Clone 
+        virtual BaseEstimator* clone() const = 0;
 };
 
 class EstimatorMixin : public virtual BaseEstimator{
     public:
-        virtual void fit(const ArrayXXd& X, const ArrayXd& y){}
-        virtual ArrayXd predict(const ArrayXXd& X){}
-        virtual float score(const ArrayXXd& X, const ArrayXd& y){}
+        virtual void fit(const ArrayXXd& X, const ArrayXd& y) = 0;
+        virtual ArrayXd predict(const ArrayXXd& X) = 0;
+        virtual float score(const ArrayXXd& X, const ArrayXd& y) = 0;
 };
 
 class RegressorMixin : public EstimatorMixin{
@@ -87,9 +89,9 @@ class ClassifierMixin : public EstimatorMixin{
 
 class TransformerMixin : public virtual BaseEstimator{
     public:
-        virtual void fit(ArrayXXd X){}
-        virtual void transform_inplace(ArrayXXd& X){}
-        virtual void inverse_transform_inplace(ArrayXXd& X){}
+        virtual void fit(ArrayXXd X) = 0;
+        virtual void transform_inplace(ArrayXXd& X) = 0;
+        virtual void inverse_transform_inplace(ArrayXXd& X) = 0;
 
         // This will return a copy from the transform_inplace function
         ArrayXXd transform(ArrayXXd X){

--- a/main.cpp
+++ b/main.cpp
@@ -38,7 +38,7 @@ int main()
                 //  {"knn", new KNeighborsClassifier(5)}});
     
     PCA* pca = new PCA(3);
-    BaseEstimator* be = new TransformerMixin;
+    BaseEstimator* be = new PCA(2);
     *be = *pca;
     cout << typeid(dynamic_cast<TransformerMixin&>(*be)).name() << endl;
     

--- a/main.cpp
+++ b/main.cpp
@@ -31,17 +31,16 @@ int main()
     hf.read("y", y);
     auto [X_train, X_test, y_train, y_test] = test_train_split(X, y, 0.3333, true);
 
-    cout << (X_test(0,0) == X.array()(0,0)) << endl;
-    cout << X_test(0,0) << endl;
-    cout << X.array()(0,0) << endl;
     //  """ Pipeline Testing """
     //  Can't do subpipe like this, no way to properly delete pointer
-    Pipeline pipe1 = Pipeline({{"pca", new PCA(2)}});
-    Pipeline pipe({  {"pipe", &pipe1 },
-                 {"knn", new KNeighborsClassifier(5)}});
+    // Pipeline pipe1 = Pipeline({{"pca", new PCA(2)}});
+    // Pipeline pipe({  {"pipe", &pipe1 },
+                //  {"knn", new KNeighborsClassifier(5)}});
     
-    pipe.fit(X,y);
-    Pipeline subpipe = pipe(0,1);
+    PCA* pca = new PCA(3);
+    BaseEstimator* be = new TransformerMixin;
+    *be = *pca;
+    cout << typeid(dynamic_cast<TransformerMixin&>(*be)).name() << endl;
     
     // Pipeline pipe2({{"pca", new PCA(10)}, {"knn", new KNeighborsClassifier(5)}});
     // cout << pipe2["knn"].is_fitted() << endl;

--- a/src/KNeighborsClassifier.cpp
+++ b/src/KNeighborsClassifier.cpp
@@ -13,7 +13,9 @@ ArrayXi n_argmax(ArrayXd& array, const int& N){
 
 // Default Constructor
 KNeighborsClassifier::KNeighborsClassifier(int n_neighbors, string weights) 
-                : n_neighbors(n_neighbors), weights(weights) {}
+                : BaseEstimator({{"n_neighbors", n_neighbors}, {"weights", weights}}),
+                n_neighbors(get<int>(params["n_neighbors"])),
+                weights(get<string>(params["weights"])) {}
 
 void KNeighborsClassifier::fit(const ArrayXXd& X, const ArrayXd& y){
     check_X_y(X, y);
@@ -33,7 +35,7 @@ ArrayXd KNeighborsClassifier::predict(const ArrayXXd& X){
         ArrayXd distance = (X_.rowwise() - x).rowwise().squaredNorm();
 
         // Get closests N indices
-        ArrayXi idxs = n_argmax(distance, n_neighbors);
+        ArrayXi idxs = n_argmax(distance, get<int>(params["n_neighbors"]));
 
         // Give weights to each label
         map<double, int> counter;

--- a/src/MinMaxScaler.cpp
+++ b/src/MinMaxScaler.cpp
@@ -2,7 +2,9 @@
 
 // Default Constructor
 MinMaxScaler::MinMaxScaler(float feature_min, float feature_max) 
-            : feature_min(feature_min), feature_max(feature_max) {}
+    : BaseEstimator({{"feature_min", feature_min},{"feature_max", feature_max}}),
+    feature_min(get<float>(params["feature_min"])), 
+    feature_max(get<float>(params["feature_max"])) {}
 
 void MinMaxScaler::fit(ArrayXXd X){
     // Make sure everything is in order

--- a/src/PCA.cpp
+++ b/src/PCA.cpp
@@ -2,13 +2,15 @@
 
 // Default Constructor
 PCA::PCA(int n_components, bool center) 
-                : n_components(n_components), center(center) {}
+    : BaseEstimator({{"n_components", n_components},{"feature_max", center}}),
+    n_components(get<int>(params["n_components"])), 
+    center(get<bool>(params["center"]))  {}
 
 void PCA::fit(ArrayXXd X){
     // Make sure everything is in order
     check_X_y(X);
     if(n_components > n_features())
-        throw std::invalid_argument( "n_components is larger than n_features" );
+        throw invalid_argument( "n_components is larger than n_features" );
 
     //Center it first if requested
     if(center){

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -16,22 +16,9 @@ Pipeline::~Pipeline(){
 }
 
 Pipeline::Pipeline(const Pipeline& other){
-    for(int i=0; i<other.steps.size()-1; i++){
-        BaseEstimator* temp = new TransformerMixin;
-        *temp = *other.steps[i].second;
-        this->steps.push_back( make_pair(other.steps[i].first, temp) );
-    }
-    // Put last element in, whether it's a transformer or estimator
-    try{
-        dynamic_cast<TransformerMixin&>( *other.steps.back().second );
-        BaseEstimator* temp = new TransformerMixin;
-        *temp = *other.steps.back().second;
-        this->steps.push_back( make_pair(other.steps.back().first, temp) );
-    }
-    catch(const bad_cast e){
-        BaseEstimator* temp = new EstimatorMixin;
-        *temp = *other.steps.back().second;
-        this->steps.push_back( make_pair(other.steps.back().first, temp) );
+    for(auto [name, step] : other.steps){
+        BaseEstimator* temp = step->clone();
+        this->steps.push_back( make_pair(name, temp) );
     }
 }
 Pipeline& Pipeline::operator=(const Pipeline& rhs){
@@ -155,6 +142,10 @@ Pipeline Pipeline::operator()(int start, int stop){
     return subpipe;
 }
 
+
+/********************************************************
+*********         Getting/Setting Params            *****
+*********************************************************/
 void Pipeline::set_params(map<string,prm> new_params){
     // Make a map for each step with it's params
     map<string,map<string,prm>> step_params;

--- a/src/RadiusNeighborsClassifier.cpp
+++ b/src/RadiusNeighborsClassifier.cpp
@@ -2,7 +2,9 @@
 
 // Default Constructor
 RadiusNeighborsClassifier::RadiusNeighborsClassifier(float radius, string weights) 
-                : radius(radius), weights(weights) {}
+    : BaseEstimator({{"radius", weights},{"feature_max", weights}}),
+    radius(get<float>(params["radius"])), 
+    weights(get<string>(params["weights"])) {}
 
 void RadiusNeighborsClassifier::fit(const ArrayXXd& X, const ArrayXd& y){
     check_X_y(X, y);

--- a/src/StandardScaler.cpp
+++ b/src/StandardScaler.cpp
@@ -2,7 +2,9 @@
 
 // Default Constructor
 StandardScaler::StandardScaler(bool with_mean, bool with_std) 
-                : with_mean(with_mean), with_std(with_std) {}
+    : BaseEstimator({{"with_mean", with_mean},{"with_std", with_std}}),
+    with_mean(get<bool>(params["with_mean"])), 
+    with_std(get<bool>(params["with_std"])) {}
 
 void StandardScaler::fit(ArrayXXd X){
     // Make sure everything is in order

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,10 +13,14 @@
 
 #include "model_selection.h"
 #include "Pipeline.h"
+#include <variant>
+
+#include <typeinfo>
 
 using namespace Eigen;
 using namespace std; 
 
+typedef variant<bool*, int*, float*, string*> prm_ptr;
 
 int main() 
 { 
@@ -29,12 +33,25 @@ int main()
     hf.read("y", y);
     auto [X_train, X_test, y_train, y_test] = test_train_split(X, y, 0.3333, true);
 
+    KNeighborsClassifier knn(5);
+    cout << "n_neighbors: " << knn.n_neighbors << endl;
+    cout << "weights: " << knn.weights << endl;
+
+    knn.set_params({{"n_neighbors", 10}, {"weights", "distance"s}});
+
+    cout << "n_neighbors: " << knn.n_neighbors << endl;
+    cout << "weights: " << knn.weights << endl;
+
+    knn.n_neighbors = 34;
+
+    cout << "n_neighbors: " << knn.n_neighbors << endl;
+
     //  """ Pipeline Testing """
-    Pipeline pipe2({{"pca", new PCA(10)}, {"knn", new KNeighborsClassifier(5)}});
-    cout << pipe2["knn"].is_fitted() << endl;
-    pipe2.fit(X_train, y_train);
-    cout << pipe2["knn"].is_fitted() << endl;
-    cout << pipe2.score(X_test, y_test) << endl;
+    // Pipeline pipe2({{"pca", new PCA(10)}, {"knn", new KNeighborsClassifier(5)}});
+    // cout << pipe2["knn"].is_fitted() << endl;
+    // pipe2.fit(X_train, y_train);
+    // cout << pipe2["knn"].is_fitted() << endl;
+    // cout << pipe2.score(X_test, y_test) << endl;
 
     // """ Transformer Testing """
     // ArrayXXd Xc = X;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,14 +37,11 @@ int main()
     cout << "n_neighbors: " << knn.n_neighbors << endl;
     cout << "weights: " << knn.weights << endl;
 
-    knn.set_params({{"n_neighbors", 10}, {"weights", "distance"s}});
+    knn.set_params({});
 
     cout << "n_neighbors: " << knn.n_neighbors << endl;
     cout << "weights: " << knn.weights << endl;
 
-    knn.n_neighbors = 34;
-
-    cout << "n_neighbors: " << knn.n_neighbors << endl;
 
     //  """ Pipeline Testing """
     // Pipeline pipe2({{"pca", new PCA(10)}, {"knn", new KNeighborsClassifier(5)}});

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,19 +13,17 @@
 
 #include "model_selection.h"
 #include "Pipeline.h"
-#include <variant>
 
-#include <typeinfo>
+#include <vector>
+#include <map>
 
 using namespace Eigen;
 using namespace std; 
 
-typedef variant<bool*, int*, float*, string*> prm_ptr;
-
 int main() 
 { 
     // Read data
-	HDF5::File hf = HDF5::File("../data/digits.h5", HDF5::File::ReadOnly);
+	HDF5::File hf = HDF5::File("../data/iris.h5", HDF5::File::ReadOnly);
     Eigen::MatrixXd X;
     Eigen::VectorXd y;
     Eigen::VectorXd y_predict;
@@ -33,22 +31,16 @@ int main()
     hf.read("y", y);
     auto [X_train, X_test, y_train, y_test] = test_train_split(X, y, 0.3333, true);
 
-    KNeighborsClassifier knn(5);
-    cout << "n_neighbors: " << knn.n_neighbors << endl;
-    cout << "weights: " << knn.weights << endl;
-
-    knn.set_params({});
-
-    cout << "n_neighbors: " << knn.n_neighbors << endl;
-    cout << "weights: " << knn.weights << endl;
-
-
     //  """ Pipeline Testing """
-    // Pipeline pipe2({{"pca", new PCA(10)}, {"knn", new KNeighborsClassifier(5)}});
-    // cout << pipe2["knn"].is_fitted() << endl;
-    // pipe2.fit(X_train, y_train);
-    // cout << pipe2["knn"].is_fitted() << endl;
-    // cout << pipe2.score(X_test, y_test) << endl;
+    //  Can't do subpipe like this, no way to properly delete pointer
+    Pipeline pipe1 = Pipeline({{"pca", new PCA(2)}});
+    Pipeline pipe({  {"pipe", &pipe1 },
+                 {"knn", new KNeighborsClassifier(5)}});
+    
+    pipe.fit(X,y);
+    Pipeline subpipe = pipe(0,1);
+    
+    
 
     // """ Transformer Testing """
     // ArrayXXd Xc = X;

--- a/templates/Classifier.cpp
+++ b/templates/Classifier.cpp
@@ -1,7 +1,12 @@
 #include "Classifier.h"
 
 // Default Constructor
-Classifier::Classifier() {}
+Classifier::Classifier(int fake_param) 
+        : BaseEstimator({{"fake_param", fake_param}}), 
+        fake_param(get<int>(params["fake_param"]) {}
+        // The actual value is saved in the base class map
+        // But we make a reference to it to make syntax easier throughout our class
+
 
 void Classifier::fit(const ArrayXXd& X, const ArrayXd& y){
     // Make sure everything is in order

--- a/templates/Classifier.h
+++ b/templates/Classifier.h
@@ -8,11 +8,17 @@ using namespace Eigen;
 
 class Classifier: public ClassifierMixin{
     public:
-        Classifier();
+        // This reference param is 100% not needed, but can be used for convenience 
+        int& fake_param;
+
+        Classifier(int fake_param);
         ~Classifier() {}
 
         void fit(const ArrayXXd& X, const ArrayXd& y);
         ArrayXd predict(const ArrayXXd& X);
+        virtual Classifier* clone() const{
+            return new Classifier(*this);
+        }
 };
 
 #endif

--- a/templates/Regressor.cpp
+++ b/templates/Regressor.cpp
@@ -1,7 +1,12 @@
 #include "Regressor.h"
 
 // Default Constructor
-Regressor::Regressor() {}
+Regressor::Regressor(int fake_param) 
+        : BaseEstimator({{"fake_param", fake_param}}), 
+        fake_param(get<int>(params["fake_param"]) {}
+        // The actual value is saved in the base class map
+        // But we make a reference to it to make syntax easier throughout our class
+
 
 void Regressor::fit(const ArrayXXd& X, const ArrayXd& y){
     // Make sure everything is in order

--- a/templates/Regressor.h
+++ b/templates/Regressor.h
@@ -8,11 +8,17 @@ using namespace Eigen;
 
 class Regressor: public RegressorMixin{
     public:
-        Regressor();
+        // This reference param is 100% not needed, but can be used for convenience 
+        int& fake_param;
+
+        Regressor(int fake_param);
         ~Regressor() {}
 
         void fit(const ArrayXXd& X, const ArrayXd& y);
         ArrayXd predict(const ArrayXXd& X);
+        virtual Regressor* clone() const{
+            return new Regressor(*this);
+        }
 };
 
 #endif

--- a/templates/Transfomer.h
+++ b/templates/Transfomer.h
@@ -8,12 +8,18 @@ using namespace Eigen;
 
 class Transfomer: public TransformerMixin{
     public:
-        Transfomer();
+        // This reference param is 100% not needed, but can be used for convenience 
+        int& fake_param;
+
+        Transfomer(int fake_param);
         ~Transfomer() {}
 
         void fit(ArrayXXd X);
         void transform_inplace(ArrayXXd& X);
         void inverse_transform_inplace(ArrayXXd& X);
+        virtual Transfomer* clone() const{
+            return new Transfomer(*this);
+        }
 };
 
 #endif

--- a/templates/Transformer.cpp
+++ b/templates/Transformer.cpp
@@ -1,7 +1,11 @@
 #include "Transfomer.h"
 
 // Default Constructor
-Transfomer::Transfomer() {}
+Transfomer::Transfomer(int fake_param) 
+        : BaseEstimator({{"fake_param", fake_param}}), 
+        fake_param(get<int>(params["fake_param"]) {}
+        // The actual value is saved in the base class map
+        // But we make a reference to it to make syntax easier throughout our class
 
 void Transfomer::fit(ArrayXXd X){
     // Make sure everything is in order

--- a/tests/test_pipe.cpp
+++ b/tests/test_pipe.cpp
@@ -61,8 +61,8 @@ TEST_F(pipeTest, Indexing){
     EXPECT_NO_THROW( Pipeline subpipe = pipe(1,3); );
     Pipeline subpipe = pipe(1,3);
     EXPECT_EQ(subpipe.steps.size(), 2);
-    // EXPECT_STREQ(subpipe.steps[0].first, "pca"s);
-    // EXPECT_STREQ(subpipe.steps[1].first, "knn"s);
+    EXPECT_NO_THROW(dynamic_cast<PCA&>(*subpipe.steps[0].second));
+    EXPECT_NO_THROW(dynamic_cast<KNeighborsClassifier&>(*subpipe.steps[1].second));
 }
 
 TEST_F(pipeTest, SetParams){

--- a/tests/test_pipe.cpp
+++ b/tests/test_pipe.cpp
@@ -1,0 +1,77 @@
+#include "gtest/gtest.h"
+#include "hdf5.hpp"
+#include "Pipeline.h"
+
+#include "StandardScaler.h"
+#include "PCA.h"
+#include "KNeighborsClassifier.h"
+
+class pipeTest : public ::testing::Test {
+    protected:
+        virtual void SetUp() {
+            // Load Data
+            HDF5::File hf = HDF5::File("../data/iris.h5", HDF5::File::ReadOnly);
+            hf.read("X", X);
+            hf.read("y", y);
+        }
+
+        Eigen::MatrixXd X;
+        Eigen::VectorXd y;
+        Pipeline pipe = Pipeline( {{"std", new StandardScaler},
+                                {"pca", new PCA(2)}, 
+                                {"knn", new KNeighborsClassifier(10)}} );
+};
+
+TEST_F(pipeTest, Methods){
+    // Check fitting
+    pipe.fit(X, y);
+    EXPECT_TRUE(pipe.is_fitted());
+    EXPECT_EQ(pipe.n_features(), X.cols());
+
+    // Check predicting
+    ArrayXd y_predict = pipe.predict(X);
+    EXPECT_EQ(y_predict.size(), y.size());
+
+    // Check scoring
+    EXPECT_NO_THROW( pipe.score(X, y) );
+}
+
+TEST_F(pipeTest, CopyProperties){
+    Pipeline copy = pipe;
+
+    // Make sure everything copied correctly
+    EXPECT_EQ(copy.steps.size(), 3);
+    EXPECT_EQ(copy.is_fitted(), pipe.is_fitted());
+
+    // Make sure they're not connected inexplicitly
+    copy.fit(X,y);
+    EXPECT_NE(copy.is_fitted(), pipe.is_fitted());
+}
+
+TEST_F(pipeTest, Indexing){
+    // Check indexing by numbers and by name
+    BaseEstimator* pca1 = pipe["pca"];
+    EXPECT_NO_THROW(dynamic_cast<PCA&>(*pca1));
+    BaseEstimator* pca2 = pipe[1];
+    EXPECT_NO_THROW(dynamic_cast<PCA&>(*pca2));
+
+    // Check copying subpipe
+    EXPECT_ANY_THROW(pipe(-1,2));
+    EXPECT_ANY_THROW(pipe(0,5));
+    EXPECT_NO_THROW( Pipeline subpipe = pipe(1,3); );
+    Pipeline subpipe = pipe(1,3);
+    EXPECT_EQ(subpipe.steps.size(), 2);
+    // EXPECT_STREQ(subpipe.steps[0].first, "pca"s);
+    // EXPECT_STREQ(subpipe.steps[1].first, "knn"s);
+}
+
+TEST_F(pipeTest, SetParams){
+    // We'll set params for each method
+    pipe.set_params({{"std__with_std", false},
+                    {"pca__n_components", 3},
+                    {"knn__n_neighbors", 30}});
+    map<string, prm> params = pipe.get_params();
+    EXPECT_FALSE(get<bool>(params["std__with_std"]));
+    EXPECT_EQ(get<int>(params["pca__n_components"]), 3);
+    EXPECT_EQ(get<int>(params["knn__n_neighbors"]), 30);
+}


### PR DESCRIPTION
Decided to go the route of having all params saved in map in base class, and then create a referenced variable to them for easier updating and using in derived classes (if desired).

The other option was to manually make methods `set_param` and `get_params` for each estimators individually which seemed more burdensome and less encapsulated (but simpler). In this other way, it also wouldn't be possible to get single param of class that had been casted as `BaseEstimator` or as some type of `Mixin`. 